### PR TITLE
Update resolver to one that works

### DIFF
--- a/mmaclone/mmaclone.cabal
+++ b/mmaclone/mmaclone.cabal
@@ -33,7 +33,9 @@ library
                       , Eval.Primitive.Primitives
                       , Eval.Primitive.PrimiFunc
                       , Eval.Primitive.Arithmatic.Arithmatic
+                      , Eval.Primitive.Attributes.Attributes
                       , Eval.Primitive.Compare.Compare
+                      , Eval.Primitive.Module.Module
                       , Eval.Primitive.List.List
                       , Eval.Primitive.List.Elem
                       , Eval.Primitive.List.Part

--- a/mmaclone/src/Data/Environment/EnvironmentType.hs
+++ b/mmaclone/src/Data/Environment/EnvironmentType.hs
@@ -1,13 +1,13 @@
-{-#LANGUAGE TemplateHaskell#-}
+{-# LANGUAGE TemplateHaskell #-}
 module Data.Environment.EnvironmentType where
 
-import Data.DataType
+import           Data.Attribute
+import           Data.DataType
 
-
-import qualified Data.Map.Strict as M
-import Control.Lens hiding (Context,List)
-import qualified Data.Text as T
-import Control.Monad.Trans.State
+import           Control.Lens              hiding (Context, List)
+import           Control.Monad.Trans.State
+import qualified Data.Map.Strict           as M
+import qualified Data.Text                 as T
 
 
 
@@ -42,13 +42,15 @@ type Primitives = M.Map T.Text Primi
 type EvalArguments = [LispVal] -> Primi
 
 
+
 -- | Envrionment for primitive function
 data PrimiEnv = PrimiEnv
   { _eval :: Eval
-  , _con :: Context
+  , _con  :: Context
   , _args :: [LispVal]
   -- , _modified :: Bool
-  , _dep :: Int
+  , _attr :: Attributes
+  , _dep  :: Int
   , _line :: Int
   }
 

--- a/mmaclone/src/Eval/Primitive/List/Part.hs
+++ b/mmaclone/src/Eval/Primitive/List/Part.hs
@@ -1,24 +1,26 @@
 module Eval.Primitive.List.Part(partl) where
-import Data.DataType
-import Data.Number.Number
-import Eval.Primitive.PrimiFunc
-import Data.Environment.EnvironmentType
+import           Data.DataType
+import           Data.Environment.EnvironmentType
+import           Data.Number.Number
+import           Eval.Primitive.PrimiFunc
 
-import Control.Monad
-import Control.Monad.Except
+import           Control.Monad
+import           Control.Monad.Except
+import           Data.Text                        (pack)
+import qualified Data.Text.Internal
 
 partl :: Primi
 partl = do
   l <- getArgumentList
   expr <- getExpression
   case partWithPartError l of
-    Left err -> stateThrow $ fromPartError err expr
+    Left err  -> stateThrow $ fromPartError err expr
     Right val -> return val
 
 
-data PartSpeci = S Int | L [Int]
+data PartSpeci = S Int | L [Int] | All | Span PartSpeci PartSpeci -- deriving (Show)
 data PartRes = Sres LispVal | Lres [LispVal]
-data PartError = Pkspec | Partw | Partd
+data PartError = Pkspec | Partw | Partd  -- | Debug Data.Text.Internal.Text
 type ThrowPart = Either PartError
 
 partWithPartError :: [LispVal] -> ThrowPart LispVal
@@ -30,22 +32,37 @@ toPartSpeci :: [LispVal] -> ThrowPart [PartSpeci]
 toPartSpeci = mapM toPartSpeci'
   where
     toPartSpeci' (List (Atom "List":res)) = liftM L $ mapM unpack res
-    toPartSpeci' n = liftM S $ unpack n
+    toPartSpeci' (List [Atom "Span",Atom "All",Atom "All"]) = Right All
+    toPartSpeci' (List [Atom "Span",Atom "All",Number (Integer b)]) = Right $ Span All (S $ fromIntegral b)
+    toPartSpeci' (List [Atom "Span",Number (Integer a),Atom "All"]) = Right $Span (S $ fromIntegral a) All
+    toPartSpeci' (List [Atom "Span",Number (Integer a),Number (Integer b)]) = Right $ Span (S $ fromIntegral a) (S $ fromIntegral b)
+    toPartSpeci' (Atom "All")             = Right All
+    toPartSpeci' n                        = liftM S $ unpack n
     unpack :: LispVal -> ThrowPart Int
     unpack (Number (Integer n)) = return (fromIntegral n)
-    unpack _ = throwError Pkspec
+    unpack _                    = throwError Pkspec
 
 partWithSpeci :: LispVal -> [PartSpeci] -> ThrowPart LispVal
 partWithSpeci l [] = return l
 partWithSpeci l (s:ss) = do
   parted <- partOnce l s
   case parted of
-    Sres res -> partWithSpeci res ss
+    Sres res   -> partWithSpeci res ss
     Lres reses -> liftM list $ mapM (`partWithSpeci` ss) reses
 
 partOnce :: LispVal -> PartSpeci -> ThrowPart PartRes
-partOnce lv (S n) = liftM Sres $ getPart lv n
+partOnce lv (S n)  = liftM Sres $ getPart lv n
 partOnce lv (L ns) = liftM Lres $ mapM (getPart lv) ns
+partOnce lv@(List ls) All    = liftM Lres $ mapM (getPart lv) [1.. (-1+length ls)]
+partOnce lv@(List ls) (Span All All)    = liftM Lres $ mapM (getPart lv) [1.. (-1+length ls)]
+partOnce lv (Span All (S n))    = liftM Lres $ mapM (getPart lv) [1.. n]
+partOnce lv (Span (S m) (S n))    = liftM Lres $ mapM (getPart lv) [m.. n]
+partOnce lv@(List ls) (Span (S n) All)    = liftM Lres $ mapM (getPart lv) [n.. (-1+length ls)]
+partOnce lv (Span _ _)    = liftM Lres $ throwError Pkspec
+partOnce _ _    = liftM Lres $ throwError Partd
+
+
+
 
 getPart :: LispVal -> Int -> ThrowPart LispVal
 getPart (List lis) n =
@@ -57,3 +74,4 @@ fromPartError :: PartError -> LispVal -> LispError
 fromPartError Partd = PartE "part specification is longer than depth of object"
 fromPartError Partw = PartE "part specification does not exist"
 fromPartError Pkspec = PartE "invalid part specification"
+--fromPartError (Debug s) = PartE s

--- a/mmaclone/src/Eval/Primitive/PrimiFunc.hs
+++ b/mmaclone/src/Eval/Primitive/PrimiFunc.hs
@@ -1,17 +1,17 @@
-{-#LANGUAGE FlexibleContexts#-}
+{-# LANGUAGE FlexibleContexts #-}
 module Eval.Primitive.PrimiFunc where
 
-import Data.DataType
-import Data.Number.Number
-import Data.Environment.EnvironmentType
+import           Data.DataType
+import           Data.Environment.EnvironmentType
+import           Data.Number.Number
 
-import qualified Data.Map.Strict as M
-import Control.Monad
-import Control.Monad.Except
-import Control.Monad.Trans.State
-import Control.Lens hiding(List, Context)
-import Data.Maybe
-import qualified Data.Text as T
+import           Control.Lens                     hiding (Context, List)
+import           Control.Monad
+import           Control.Monad.Except
+import           Control.Monad.Trans.State
+import qualified Data.Map.Strict                  as M
+import           Data.Maybe
+import qualified Data.Text                        as T
 
 stateThrow :: LispError -> StateResult a
 stateThrow = lift . throwError
@@ -60,6 +60,8 @@ getLineNumber = use line
 -- | update context
 updateCon :: (Context -> Context) -> StateResult ()
 updateCon f = con %= f
+
+
 
 
 -- | return args

--- a/mmaclone/src/Eval/Primitive/Primitives.hs
+++ b/mmaclone/src/Eval/Primitive/Primitives.hs
@@ -1,22 +1,46 @@
 module Eval.Primitive.Primitives(primitives) where
 
-import Eval.Primitive.PrimiFunc
-import Data.Environment.EnvironmentType
-import Eval.Primitive.Arithmatic.Arithmatic
-import Eval.Primitive.List.List
-import Eval.Primitive.Compare.Compare
-import Eval.Primitive.Logic.Logic
-import Eval.Primitive.Control.Branch
-import Eval.Primitive.Function.Lambda
-import Eval.Primitive.Replace.Replace
-import Eval.Primitive.Nest.Nest
-import Eval.Primitive.Set.Set
-import Eval.Primitive.IO.Print
-import Eval.Primitive.InOut.InOut
+import           Data.Environment.EnvironmentType
+import           Eval.Primitive.Arithmatic.Arithmatic
+import           Eval.Primitive.Attributes.Attributes
+import           Eval.Primitive.Compare.Compare
+import           Eval.Primitive.Control.Branch
+import           Eval.Primitive.Function.Lambda
+import           Eval.Primitive.InOut.InOut
+import           Eval.Primitive.IO.Print
+import           Eval.Primitive.List.List
+import           Eval.Primitive.Logic.Logic
+import           Eval.Primitive.Module.Module
+import           Eval.Primitive.Nest.Nest
+import           Eval.Primitive.PrimiFunc
+import           Eval.Primitive.Replace.Replace
+import           Eval.Primitive.Set.Set
+
+import qualified Data.Map.Strict                      as M
+import qualified Data.Text                            as T
 
 
-import qualified Data.Text as T
-import qualified Data.Map.Strict as M
+import           Data.Attribute
+import           Data.DataType
+import           Data.Environment.Environment
+import           Data.Environment.Update
+import           Eval.Patt.Pattern
+import           Eval.Primitive.PrimiFunc
+
+import           Control.Monad
+import           Control.Monad.Except
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Except
+import           Data.IORef
+
+import           Control.Lens                         hiding (Context, List)
+import           Control.Monad
+import           Control.Monad.Except
+import           Control.Monad.Trans.State
+import           Data.Maybe                           (fromMaybe)
+
+
+
 
 -- | Collections of all primitive function
 primitives :: M.Map T.Text Primi
@@ -72,6 +96,10 @@ primitives = M.fromList
 
   , ("Condition", conditionl)
   , ("Pattern", patternl)
+  , ("GetAttributes", getAttributesl)
+  , ("SetAttributes", setAttributesl)
+  , ("Module", modulel)
+  , ("Unset", unsetl)
   ]
 
 
@@ -89,3 +117,7 @@ patternl :: Primi
 patternl = do
   withnop 2
   noChange
+
+
+
+

--- a/mmaclone/src/Eval/Primitive/Set/Set.hs
+++ b/mmaclone/src/Eval/Primitive/Set/Set.hs
@@ -1,18 +1,18 @@
 module Eval.Primitive.Set.Set
-        (setl,setDelayedl) where
+        (setl,setDelayedl,unsetl) where
 
-import Data.DataType
-import Eval.Primitive.PrimiFunc
-import Data.Environment.Environment
-import Data.Environment.EnvironmentType
-import Data.Environment.Update
-import Eval.Patt.Pattern
+import           Data.DataType
+import           Data.Environment.Environment
+import           Data.Environment.EnvironmentType
+import           Data.Environment.Update
+import           Eval.Patt.Pattern
+import           Eval.Primitive.PrimiFunc
 
-import Data.IORef
-import Control.Monad
-import Control.Monad.IO.Class
-import Control.Monad.Trans.Except
-import Control.Monad.Except
+import           Control.Monad
+import           Control.Monad.Except
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Except
+import           Data.IORef
 
 
 setl :: Primi
@@ -31,3 +31,10 @@ setVar lhs rhs =
   if validSet lhs then setVariable lhs rhs
   else
     throwError $ SetError lhs
+
+unsetl :: Primi
+unsetl = do
+   withnop 1
+   [a] <- getArgumentList
+   updateCon (unset a)
+   return a

--- a/mmaclone/src/Parser/NewParse.hs
+++ b/mmaclone/src/Parser/NewParse.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Parser.NewParse(Expr(..), parseExpr,Stage1,expr) where
 
-import Text.Parsec hiding (Empty)
-import Text.Parsec.String
-import qualified Text.Parsec.Token as Token
-import Text.Parsec.Language
+import           Text.Parsec          hiding (Empty)
+import           Text.Parsec.Language
+import           Text.Parsec.String
+import qualified Text.Parsec.Token    as Token
 -- import Control.Applicative((*>))
-import Text.Parsec.Expr
+import           Text.Parsec.Expr
 
-import Data.Number.Number
-import qualified Data.Text as T
+import           Data.Number.Number
+import qualified Data.Text            as T
 
 data Expr
   = Num Number
@@ -69,6 +69,8 @@ data Expr
    | None
    | Cond Expr Expr
    | Alter Expr Expr
+   | GetAttributes Expr
+   | SetAttributes Expr Expr
    deriving (Show,Eq)
 
 opNames = words ("-> :> && || ! + - * / ; == < <= > >= : @ @@ /@ //@ @@@ \' !! != /. //. = :="
@@ -222,7 +224,7 @@ number = do
   num <- naturalOrFloat
   let numE = case num of
               Left a  -> Integer a
-              Right b  -> Double b
+              Right b -> Double b
   -- return (s $ Number numE)
   return (Num numE)
 

--- a/mmaclone/stack.yaml
+++ b/mmaclone/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.2
+resolver: lts-11.22
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
I have updated the stack.yaml file to use a newer resolver.  The old version gives this error when compiling with stack resolver lts-5.2:

WARNING: Ignoring out of range dependency (trusting snapshot over Hackage revisions): tagged-0.8.3. semigroupoids requires: >=0.8.5 && <1
semigroupoids-5.0.1: configure
Progress 1/6

--  While building custom Setup.hs for package semigroupoids-5.0.1 using:
      /tmp/stack15107/semigroupoids-5.0.1/.stack-work/dist/x86_64-linux/Cabal-1.22.5.0/setup/setup --builddir=.stack-work/dist/x86_64-linux/Cabal-1.22.5.0 configure --with-ghc=/home/jholland/.stack/programs/x86_64-linux/ghc-7.10.3/bin/ghc --with-ghc-pkg=/home/jholland/.stack/programs/x86_64-linux/ghc-7.10.3/bin/ghc-pkg --user --package-db=clear --package-db=global --package-db=/home/jholland/.stack/snapshots/x86_64-linux/lts-5.2/7.10.3/pkgdb --libdir=/home/jholland/.stack/snapshots/x86_64-linux/lts-5.2/7.10.3/lib --bindir=/home/jholland/.stack/snapshots/x86_64-linux/lts-5.2/7.10.3/bin --datadir=/home/jholland/.stack/snapshots/x86_64-linux/lts-5.2/7.10.3/share --libexecdir=/home/jholland/.stack/snapshots/x86_64-linux/lts-5.2/7.10.3/libexec --sysconfdir=/home/jholland/.stack/snapshots/x86_64-linux/lts-5.2/7.10.3/etc --docdir=/home/jholland/.stack/snapshots/x86_64-linux/lts-5.2/7.10.3/doc/semigroupoids-5.0.1 --htmldir=/home/jholland/.stack/snapshots/x86_64-linux/lts-5.2/7.10.3/doc/semigroupoids-5.0.1 --haddockdir=/home/jholland/.stack/snapshots/x86_64-linux/lts-5.2/7.10.3/doc/semigroupoids-5.0.1 --dependency=base=base-4.8.2.0-0d6d1084fbc041e1cded9228e80e264d --dependency=base-orphans=base-orphans-0.5.1-925e1d3fe5ba9df0b0ed3006818691c2 --dependency=bifunctors=bifunctors-5.2-195caea8c784f946797fa1e2dbfea7a8 --dependency=comonad=comonad-4.2.7.2-47cbca42702497de4a7668cd5119be60 --dependency=containers=containers-0.5.6.2-59326c33e30ec8f6afd574cbac625bbb --dependency=contravariant=contravariant-1.4-21957ee41ab998a9d7a816ce208368f1 --dependency=distributive=distributive-0.5.0.2-5908fc39fd832a65886841359058e6c4 --dependency=semigroups=semigroups-0.18.1-5c35a5b826413daa75611e5ffd4860ed --dependency=tagged=tagged-0.8.3-21c7d9e94c80e78986722ec9a3df67cf --dependency=transformers=transformers-0.4.2.0-81450cd8f86b36eaa8fa0cbaf6efc3a3 --dependency=transformers-compat=transformers-compat-0.4.0.4-8aa4073730c676dbe210ea8bffd8d092
    Process exited with code: ExitFailure 1
    Logs have been written to: /tmp/mmaclone/mmaclone/.stack-work/logs/semigroupoids-5.0.1.log

    [1 of 2] Compiling Main             ( /tmp/stack15107/semigroupoids-5.0.1/Setup.lhs, /tmp/stack15107/semigroupoids-5.0.1/.stack-work/dist/x86_64-linux/Cabal-1.22.5.0/setup/Main.o )
    [2 of 2] Compiling StackSetupShim   ( /home/jholland/.stack/setup-exe-src/setup-shim-mPHDZzAJ.hs, /tmp/stack15107/semigroupoids-5.0.1/.stack-work/dist/x86_64-linux/Cabal-1.22.5.0/setup/StackSetupShim.o )
    Linking /tmp/stack15107/semigroupoids-5.0.1/.stack-work/dist/x86_64-linux/Cabal-1.22.5.0/setup/setup ...
    Configuring semigroupoids-5.0.1...
    setup: At least the following dependencies are missing:
    tagged >=0.8.5 && <1 && ==0.8.3
